### PR TITLE
[coverage-autofix] tests: improve coverage from 84% to 100%

### DIFF
--- a/tests/test_purpleair_data_logger.py
+++ b/tests/test_purpleair_data_logger.py
@@ -7,6 +7,10 @@ Copyright 2023 carlkidcrypto, All rights reserved.
 import unittest
 import requests_mock
 import sys
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
 
 sys.path.append("../")
 
@@ -78,3 +82,217 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             padl.store_sensor_data({})
+
+    def test_purpleair_data_logger_setter_raises_on_low_value(self):
+        """
+        Test that PurpleAirDataLoggerError is raised when setting
+        send_request_every_x_seconds to a value less than 60.
+        """
+
+        expected_url_request = "https://api.purpleair.com/v1/keys"
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                expected_url_request,
+                text='{"api_version" : "1.1.1", "time_stamp": 123456789, "api_key_type": "READ"}',
+                status_code=200,
+            )
+            padl = PurpleAirDataLogger(PurpleAirApiReadKey="123456789")
+
+        with self.assertRaises(PurpleAirDataLoggerError):
+            padl.send_request_every_x_seconds = 59
+
+    def _make_padl_with_mock(self):
+        """Helper to create a PurpleAirDataLogger with a mocked read key."""
+        expected_url_request = "https://api.purpleair.com/v1/keys"
+        with requests_mock.Mocker() as m:
+            m.get(
+                expected_url_request,
+                text='{"api_version" : "1.1.1", "time_stamp": 123456789, "api_key_type": "READ"}',
+                status_code=200,
+            )
+            padl = PurpleAirDataLogger(PurpleAirApiReadKey="123456789")
+        return padl
+
+    def test_validate_parameters_and_run_all_none_raises(self):
+        """
+        Test that validate_parameters_and_run raises when all args are None.
+        """
+        padl = self._make_padl_with_mock()
+        with self.assertRaises(PurpleAirDataLoggerError):
+            padl.validate_parameters_and_run()
+
+    def test_validate_parameters_and_run_multiple_provided_raises(self):
+        """
+        Test that validate_parameters_and_run raises when multiple args are provided.
+        """
+        padl = self._make_padl_with_mock()
+        with self.assertRaises(PurpleAirDataLoggerError):
+            padl.validate_parameters_and_run(
+                paa_single_sensor_request_json_file="a.json",
+                paa_multiple_sensor_request_json_file="b.json",
+            )
+
+    def test_validate_parameters_and_run_single_sensor(self):
+        """
+        Test that validate_parameters_and_run calls the single-sensor run loop.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"poll_interval_seconds": 60, "sensor_index": 53, "read_key": None, "fields": None}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(config, f)
+            tmp_path = f.name
+        try:
+            with patch.object(
+                padl, "_run_loop_for_storing_single_sensor_data"
+            ) as mock_run:
+                padl.validate_parameters_and_run(
+                    paa_single_sensor_request_json_file=tmp_path
+                )
+                mock_run.assert_called_once_with(config)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_validate_parameters_and_run_multiple_sensors(self):
+        """
+        Test that validate_parameters_and_run calls the multiple-sensor run loop.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"poll_interval_seconds": 60, "fields": "name"}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(config, f)
+            tmp_path = f.name
+        try:
+            with patch.object(
+                padl, "_run_loop_for_storing_multiple_sensors_data"
+            ) as mock_run:
+                padl.validate_parameters_and_run(
+                    paa_multiple_sensor_request_json_file=tmp_path
+                )
+                mock_run.assert_called_once_with(config)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_validate_parameters_and_run_group_sensors(self):
+        """
+        Test that validate_parameters_and_run calls the group-sensor run loop.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"poll_interval_seconds": 60, "sensor_group_name": "test", "add_sensors_to_group": False, "sensor_index_list": [], "fields": "name"}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(config, f)
+            tmp_path = f.name
+        try:
+            with patch.object(
+                padl, "_run_loop_for_storing_group_sensors_data"
+            ) as mock_run:
+                padl.validate_parameters_and_run(
+                    paa_group_sensor_request_json_file=tmp_path
+                )
+                mock_run.assert_called_once_with(config)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_validate_parameters_and_run_local_sensors(self):
+        """
+        Test that validate_parameters_and_run calls the local-sensor run loop.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"sensor_ip_list": ["192.168.1.1"], "poll_interval_seconds": 60}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(config, f)
+            tmp_path = f.name
+        try:
+            with patch.object(
+                padl, "_run_loop_for_storing_local_sensors_data"
+            ) as mock_run:
+                padl.validate_parameters_and_run(
+                    paa_local_sensor_request_json_file=tmp_path
+                )
+                mock_run.assert_called_once_with(config)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_run_loop_for_storing_single_sensor_data(self):
+        """
+        Test that _run_loop_for_storing_single_sensor_data sets the poll interval
+        and calls logic once before sleep breaks out.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"poll_interval_seconds": 65, "sensor_index": 53, "read_key": None, "fields": None}
+
+        with patch(
+            "purpleair_data_logger.PurpleAirDataLogger.logic_for_storing_single_sensor_data"
+        ) as mock_logic, patch(
+            "purpleair_data_logger.PurpleAirDataLogger.sleep",
+            side_effect=StopIteration,
+        ):
+            with self.assertRaises(StopIteration):
+                padl._run_loop_for_storing_single_sensor_data(config)
+        mock_logic.assert_called_once_with(padl, config)
+        self.assertEqual(padl.send_request_every_x_seconds, 65)
+
+    def test_run_loop_for_storing_multiple_sensors_data(self):
+        """
+        Test that _run_loop_for_storing_multiple_sensors_data sets the poll interval
+        and calls logic once before sleep breaks out.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"poll_interval_seconds": 65, "fields": "name"}
+
+        with patch(
+            "purpleair_data_logger.PurpleAirDataLogger.logic_for_storing_multiple_sensors_data"
+        ) as mock_logic, patch(
+            "purpleair_data_logger.PurpleAirDataLogger.sleep",
+            side_effect=StopIteration,
+        ):
+            with self.assertRaises(StopIteration):
+                padl._run_loop_for_storing_multiple_sensors_data(config)
+        mock_logic.assert_called_once_with(padl, config)
+        self.assertEqual(padl.send_request_every_x_seconds, 65)
+
+    def test_run_loop_for_storing_group_sensors_data(self):
+        """
+        Test that _run_loop_for_storing_group_sensors_data sets the poll interval
+        and calls logic once before sleep breaks out.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"poll_interval_seconds": 65, "fields": "name", "sensor_group_name": "test"}
+
+        with patch(
+            "purpleair_data_logger.PurpleAirDataLogger.logic_for_storing_group_sensors_data",
+            return_value=42,
+        ) as mock_logic, patch(
+            "purpleair_data_logger.PurpleAirDataLogger.sleep",
+            side_effect=StopIteration,
+        ):
+            with self.assertRaises(StopIteration):
+                padl._run_loop_for_storing_group_sensors_data(config)
+        mock_logic.assert_called_once_with(padl, None, config)
+        self.assertEqual(padl.send_request_every_x_seconds, 65)
+
+    def test_run_loop_for_storing_local_sensors_data(self):
+        """
+        Test that _run_loop_for_storing_local_sensors_data calls logic once
+        before sleep breaks out.
+        """
+        padl = self._make_padl_with_mock()
+        config = {"sensor_ip_list": ["192.168.1.1"], "poll_interval_seconds": 65}
+
+        with patch(
+            "purpleair_data_logger.PurpleAirDataLogger.logic_for_storing_local_sensors_data"
+        ) as mock_logic, patch(
+            "purpleair_data_logger.PurpleAirDataLogger.sleep",
+            side_effect=StopIteration,
+        ):
+            with self.assertRaises(StopIteration):
+                padl._run_loop_for_storing_local_sensors_data(config)
+        mock_logic.assert_called_once_with(padl, config)

--- a/tests/test_purpleair_data_logger.py
+++ b/tests/test_purpleair_data_logger.py
@@ -89,15 +89,7 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         send_request_every_x_seconds to a value less than 60.
         """
 
-        expected_url_request = "https://api.purpleair.com/v1/keys"
-
-        with requests_mock.Mocker() as m:
-            m.get(
-                expected_url_request,
-                text='{"api_version" : "1.1.1", "time_stamp": 123456789, "api_key_type": "READ"}',
-                status_code=200,
-            )
-            padl = PurpleAirDataLogger(PurpleAirApiReadKey="123456789")
+        padl = self._make_padl_with_mock()
 
         with self.assertRaises(PurpleAirDataLoggerError):
             padl.send_request_every_x_seconds = 59

--- a/tests/test_purpleair_data_logger.py
+++ b/tests/test_purpleair_data_logger.py
@@ -130,10 +130,13 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         Test that validate_parameters_and_run calls the single-sensor run loop.
         """
         padl = self._make_padl_with_mock()
-        config = {"poll_interval_seconds": 60, "sensor_index": 53, "read_key": None, "fields": None}
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        config = {
+            "poll_interval_seconds": 60,
+            "sensor_index": 53,
+            "read_key": None,
+            "fields": None,
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(config, f)
             tmp_path = f.name
         try:
@@ -153,9 +156,7 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         """
         padl = self._make_padl_with_mock()
         config = {"poll_interval_seconds": 60, "fields": "name"}
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(config, f)
             tmp_path = f.name
         try:
@@ -174,10 +175,14 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         Test that validate_parameters_and_run calls the group-sensor run loop.
         """
         padl = self._make_padl_with_mock()
-        config = {"poll_interval_seconds": 60, "sensor_group_name": "test", "add_sensors_to_group": False, "sensor_index_list": [], "fields": "name"}
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        config = {
+            "poll_interval_seconds": 60,
+            "sensor_group_name": "test",
+            "add_sensors_to_group": False,
+            "sensor_index_list": [],
+            "fields": "name",
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(config, f)
             tmp_path = f.name
         try:
@@ -197,9 +202,7 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         """
         padl = self._make_padl_with_mock()
         config = {"sensor_ip_list": ["192.168.1.1"], "poll_interval_seconds": 60}
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(config, f)
             tmp_path = f.name
         try:
@@ -219,7 +222,12 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         and calls logic once before sleep breaks out.
         """
         padl = self._make_padl_with_mock()
-        config = {"poll_interval_seconds": 65, "sensor_index": 53, "read_key": None, "fields": None}
+        config = {
+            "poll_interval_seconds": 65,
+            "sensor_index": 53,
+            "read_key": None,
+            "fields": None,
+        }
 
         with patch(
             "purpleair_data_logger.PurpleAirDataLogger.logic_for_storing_single_sensor_data"
@@ -257,7 +265,11 @@ class PurpleAirDataLoggerTest(unittest.TestCase):
         and calls logic once before sleep breaks out.
         """
         padl = self._make_padl_with_mock()
-        config = {"poll_interval_seconds": 65, "fields": "name", "sensor_group_name": "test"}
+        config = {
+            "poll_interval_seconds": 65,
+            "fields": "name",
+            "sensor_group_name": "test",
+        }
 
         with patch(
             "purpleair_data_logger.PurpleAirDataLogger.logic_for_storing_group_sensors_data",

--- a/tests/test_purpleair_data_logger_helpers.py
+++ b/tests/test_purpleair_data_logger_helpers.py
@@ -604,3 +604,114 @@ class PurpleAirDataLoggerHelpersTest(unittest.TestCase):
                 logic_for_storing_local_sensors_data(padl, json_config_file)
                 padl.store_sensor_data.return_value = None
                 padl.store_sensor_data.assert_called_once_with(test_data_out[index])
+
+    def test_logic_for_storing_group_sensors_data_with_add_sensors_false(self):
+        """
+        Test the branch where add_sensors_to_group is False — sensors should NOT be added.
+        """
+
+        expected_url_request = "https://api.purpleair.com/v1/keys"
+        padl = None
+        with requests_mock.Mocker() as m:
+            m.get(
+                expected_url_request,
+                text='{"api_version" : "1.1.1", "time_stamp": 123456789, "api_key_type": "READ"}',
+                status_code=200,
+            )
+            padl = PurpleAirDataLogger(PurpleAirApiReadKey="123456789")
+            padl.store_sensor_data = MagicMock(name="store_sensor_data")
+            json_config_file = {
+                "sensor_group_name": "A Name Goes Here",
+                "add_sensors_to_group": False,
+                "sensor_index_list": [77],
+                "poll_interval_seconds": 60,
+                "fields": "name",
+                "location_type": None,
+                "read_keys": None,
+                "show_only": None,
+                "modified_since": None,
+                "max_age": None,
+                "nwlng": None,
+                "nwlat": None,
+                "selng": None,
+                "selat": None,
+            }
+
+        expected_groups = {"groups": [{"name": "A Name Goes Here", "id": 9999}]}
+        expected_members_data = {
+            "api_version": "V1.0.11-0.0.42",
+            "time_stamp": 1676784867,
+            "data_time_stamp": 1676784847,
+            "group_id": 9999,
+            "max_age": 604800,
+            "firmware_default_version": "7.02",
+            "fields": ["sensor_index", "name"],
+            "data": [[77, "Sunnyside"]],
+        }
+
+        with requests_mock.Mocker() as m1:
+            m1.get(
+                "https://api.purpleair.com/v1/groups/",
+                text=f"{dumps(expected_groups)}",
+                status_code=200,
+            )
+            m1.get(
+                "https://api.purpleair.com/v1/groups/9999/members?fields=name",
+                text=f"{dumps(expected_members_data)}",
+                status_code=200,
+            )
+            result = logic_for_storing_group_sensors_data(padl, None, json_config_file)
+            self.assertEqual(result, 9999)
+
+    def test_logic_for_storing_group_sensors_data_reraises_non_duplicate_error(self):
+        """
+        Test that a non-duplicate PurpleAirAPIError is re-raised when adding sensors.
+        """
+        from purpleair_api.PurpleAirAPI import PurpleAirAPIError
+
+        expected_url_request = "https://api.purpleair.com/v1/keys"
+        padl = None
+        with requests_mock.Mocker() as m:
+            m.get(
+                expected_url_request,
+                text='{"api_version" : "1.1.1", "time_stamp": 123456789, "api_key_type": "READ"}',
+                status_code=200,
+            )
+            padl = PurpleAirDataLogger(PurpleAirApiReadKey="123456789")
+            padl.store_sensor_data = MagicMock(name="store_sensor_data")
+            json_config_file = {
+                "sensor_group_name": "A Name Goes Here",
+                "add_sensors_to_group": True,
+                "sensor_index_list": [77],
+                "poll_interval_seconds": 60,
+                "fields": "name",
+                "location_type": None,
+                "read_keys": None,
+                "show_only": None,
+                "modified_since": None,
+                "max_age": None,
+                "nwlng": None,
+                "nwlat": None,
+                "selng": None,
+                "selat": None,
+            }
+
+        expected_groups = {"groups": [{"name": "A Name Goes Here", "id": 8888}]}
+        non_duplicate_error_response = {
+            "error": 403,
+            "description": "403: Forbidden - Access denied.",
+        }
+
+        with requests_mock.Mocker() as m1:
+            m1.get(
+                "https://api.purpleair.com/v1/groups/",
+                text=f"{dumps(expected_groups)}",
+                status_code=200,
+            )
+            m1.post(
+                "https://api.purpleair.com/v1/groups/8888/members",
+                text=f"{dumps(non_duplicate_error_response)}",
+                status_code=403,
+            )
+            with self.assertRaises(PurpleAirAPIError):
+                logic_for_storing_group_sensors_data(padl, None, json_config_file)


### PR DESCRIPTION
Add missing test cases for PurpleAirDataLogger and PurpleAirDataLoggerHelpers:

- test_purpleair_data_logger.py:
  - Test setter raises PurpleAirDataLoggerError when value < 60
  - Test validate_parameters_and_run raises when all args are None
  - Test validate_parameters_and_run raises when multiple args provided
  - Test validate_parameters_and_run dispatches to each run-loop variant
  - Test each _run_loop_for_storing_*_data method via patched sleep/logic

- test_purpleair_data_logger_helpers.py:
  - Test logic_for_storing_group_sensors_data with add_sensors_to_group=False
  - Test logic_for_storing_group_sensors_data re-raises non-duplicate errors