### PR TITLE
[docs-improvement] Fix docstring and comment errors across data logger modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ usage: PurpleAirSQLiteDataLogger.py [-h] [-paa_read_key PAA_READ_KEY] [-paa_writ
                                     [-paa_multiple_sensor_request_json_file PAA_MULTIPLE_SENSOR_REQUEST_JSON_FILE] [-paa_group_sensor_request_json_file PAA_GROUP_SENSOR_REQUEST_JSON_FILE]
                                     [-paa_local_sensor_request_json_file PAA_LOCAL_SENSOR_REQUEST_JSON_FILE] -db_name DB_NAME
 
-Collect data from PurpleAir sensors and store it a SQLite3 database file!
+Collect data from PurpleAir sensors and store it in a SQLite3 database file!
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/purpleair_data_logger/PurpleAirCSVDataLogger.py
+++ b/purpleair_data_logger/PurpleAirCSVDataLogger.py
@@ -62,7 +62,7 @@ class PurpleAirCSVDataLogger(PurpleAirDataLogger):
         :param str PurpleAirApiReadKey: A valid PurpleAirAPI Read key
         :param str PurpleAirApiWriteKey: A valid PurpleAirAPI Write key
         :param list PurpleAirApiIpv4Address: A list of valid IPv4 string addresses with no CIDR's.
-        :param object path_to_save_csv_files_in: A string directory path
+        :param str path_to_save_csv_files_in: A string directory path
                                                  to save files in.
         """
 

--- a/purpleair_data_logger/PurpleAirDataLogger.py
+++ b/purpleair_data_logger/PurpleAirDataLogger.py
@@ -41,7 +41,8 @@ class PurpleAirDataLogger:
     ):
         """
         :param str PurpleAirApiReadKey: A valid PurpleAirAPI Read key
-        :param object psql_db_conn: A valid PG8000 database connection
+        :param str PurpleAirApiWriteKey: A valid PurpleAirAPI Write key
+        :param list PurpleAirApiIpv4Address: A list of valid IPv4 string addresses for local sensor access
         """
 
         # Make one instance of our PurpleAirAPI class
@@ -151,7 +152,7 @@ class PurpleAirDataLogger:
             )
             sleep(self.send_request_every_x_seconds)
 
-    def _run_loop_for_storing_local_sensors_data(self, json_config_file) -> dict:
+    def _run_loop_for_storing_local_sensors_data(self, json_config_file) -> None:
         """
         A method containing the run loop for inserting a local sensors' data into the data logger.
 
@@ -177,9 +178,9 @@ class PurpleAirDataLogger:
         This shall be considered the main entry point for and PurpleAirDataLogger.
 
         :param str paa_multiple_sensor_request_json_file: The path to a json file containing
-                                                          the parameters to send a single sensor request(s).
+                                                          the parameters to send a multiple sensor request(s).
         :param str paa_single_sensor_request_json_file: The path to a json file containing
-                                                        the parameters to send a multiple sensor request(s).
+                                                        the parameters to send a single sensor request(s).
         :param str paa_group_sensor_request_json_file: The path to a json file containing
                                                         the parameters to send a group sensor request(s).
         :param str paa_local_sensor_request_json_file: The path to a json file containing

--- a/purpleair_data_logger/PurpleAirDataLoggerHelpers.py
+++ b/purpleair_data_logger/PurpleAirDataLoggerHelpers.py
@@ -294,7 +294,7 @@ def logic_for_storing_group_sensors_data(
 
     :param PurpleAirDataLogger padl_obj: A valid instance of PurpleAirDataLogger.
 
-    :param str group_id_to_use: The group id to be used. Starts out being `None` then gets filled out.
+    :param int group_id_to_use: The group id to be used. Starts out being `None` then gets filled out.
 
     :param dict json_config_file: A dictionary object of the json config file using json load.
 

--- a/purpleair_data_logger/PurpleAirDataLoggerHelpers.py
+++ b/purpleair_data_logger/PurpleAirDataLoggerHelpers.py
@@ -94,7 +94,7 @@ def validate_sensor_data_before_insert(the_modified_sensor_data) -> dict:
 
     :param dict the_modified_sensor_data: A single layer dictionary containing a single sensors data.
 
-    return A dictionary with all the data fields filled out.
+    :return: A dictionary with all the data fields filled out.
     """
 
     # Make a copy first
@@ -294,7 +294,7 @@ def logic_for_storing_group_sensors_data(
 
     :param PurpleAirDataLogger padl_obj: A valid instance of PurpleAirDataLogger.
 
-    :param str: The group id to be used. Starts out being `None` then gets filled out.
+    :param str group_id_to_use: The group id to be used. Starts out being `None` then gets filled out.
 
     :param dict json_config_file: A dictionary object of the json config file using json load.
 

--- a/purpleair_data_logger/PurpleAirPSQLDataLogger.py
+++ b/purpleair_data_logger/PurpleAirPSQLDataLogger.py
@@ -61,6 +61,7 @@ class PurpleAirPSQLDataLogger(PurpleAirDataLogger):
     def __init__(self, PurpleAirAPIReadKey, PurpleAirAPIWriteKey, psql_db_conn):
         """
         :param str PurpleAirAPIReadKey: A valid PurpleAirAPI Read key
+        :param str PurpleAirAPIWriteKey: A valid PurpleAirAPI Write key
         :param object psql_db_conn: A valid PG8000 database connection
         """
 

--- a/purpleair_data_logger/PurpleAirSQLiteDataLogger.py
+++ b/purpleair_data_logger/PurpleAirSQLiteDataLogger.py
@@ -56,6 +56,8 @@ class PurpleAirSQLiteDataLogger(PurpleAirDataLogger):
     ):
         """
         :param str PurpleAirAPIReadKey: A valid PurpleAirAPI Read key
+        :param str PurpleAirAPIWriteKey: A valid PurpleAirAPI Write key
+        :param str sqlite_data_base_name: The path and name for the SQLite3 database file (e.g. database_name.db)
         """
 
         # Inherit everything from the parent base class: PurpleAirDataLogger
@@ -63,7 +65,7 @@ class PurpleAirSQLiteDataLogger(PurpleAirDataLogger):
 
         self._db_conn = sqlite3.connect(sqlite_data_base_name)
 
-        # Make our PSQL Tables
+        # Make our SQLite Tables
         self._create_sqlite_db_tables()
 
     def _create_sqlite_db_tables(self):


### PR DESCRIPTION
- PurpleAirDataLogger.__init__: replace incorrect psql_db_conn param doc with correct PurpleAirApiWriteKey and PurpleAirApiIpv4Address
- PurpleAirDataLogger.validate_parameters_and_run: fix swapped descriptions for paa_multiple/single_sensor_request_json_file params
- PurpleAirDataLogger._run_loop_for_storing_local_sensors_data: fix return type annotation from dict to None
- PurpleAirDataLoggerHelpers.validate_sensor_data_before_insert: fix missing colon on :return: directive
- PurpleAirDataLoggerHelpers.logic_for_storing_group_sensors_data: add missing parameter name to :param str group_id_to_use: directive
- PurpleAirPSQLDataLogger.__init__: add missing PurpleAirAPIWriteKey param doc
- PurpleAirSQLiteDataLogger.__init__: add missing PurpleAirAPIWriteKey and sqlite_data_base_name param docs
- PurpleAirSQLiteDataLogger._create_sqlite_db_tables: fix copy-paste comment 'PSQL Tables' -> 'SQLite Tables'
- PurpleAirCSVDataLogger.__init__: fix param type 'object' -> 'str' for path_to_save_csv_files_in
- README.md: fix grammar 'store it a SQLite3' -> 'store it in a SQLite3'