### PR TITLE
Fix documentation typos and docstrings

### DIFF
--- a/external_network_hardware_variant_json_samples/README.md
+++ b/external_network_hardware_variant_json_samples/README.md
@@ -1,4 +1,4 @@
 # External Network Hardware Variant Json Samples
 
 This directory contains responses from different devices (hardware variants) that
-are publical accessible via the Purpleair API.
+are publicly accessible via the PurpleAir API.

--- a/internal_network_hardware_variant_json_samples/README.md
+++ b/internal_network_hardware_variant_json_samples/README.md
@@ -1,4 +1,4 @@
 # Internal Network Hardware Variant Json Samples
 
-This directory contains response from different devices (hardware variants) that
-are privatley accessible via the local network Purpleair API.
+This directory contains responses from different devices (hardware variants) that
+are privately accessible via the local network PurpleAir API.

--- a/purpleair_data_logger/PurpleAirCSVDataLogger.py
+++ b/purpleair_data_logger/PurpleAirCSVDataLogger.py
@@ -85,6 +85,8 @@ class PurpleAirCSVDataLogger(PurpleAirDataLogger):
 
         :param str file_path_and_name: A string of 'file_path_and_name'. i.e
                                        '/path_to_place/file_name.csv'.
+        :return: An open file stream for the CSV file.
+        :rtype: file object
         """
         the_file_stream = open(file_path_and_name, "a")
         return the_file_stream

--- a/purpleair_data_logger/PurpleAirPSQLDataLogger.py
+++ b/purpleair_data_logger/PurpleAirPSQLDataLogger.py
@@ -222,6 +222,7 @@ class PurpleAirPSQLDataLogger(PurpleAirDataLogger):
         :param int unix_epoch_timestamp: A valid unix epoch timestamp
 
         :return: A valid psql UTC timestamp or None.
+        :rtype: str or None
         """
 
         if unix_epoch_timestamp is None:

--- a/purpleair_data_logger/PurpleAirSQLiteDataLogger.py
+++ b/purpleair_data_logger/PurpleAirSQLiteDataLogger.py
@@ -70,7 +70,7 @@ class PurpleAirSQLiteDataLogger(PurpleAirDataLogger):
 
     def _create_sqlite_db_tables(self):
         """
-        Create the SQLITE database tables if they don't exist already
+        Create the SQLite database tables if they don't exist already
 
         We will create one table for different data groups. Simply following the
         official PurpleAir documentation. Think Station information and status fields,

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ python3 -m pip install coverage
 python3 -m pip install requests-mock
 ```
 
-3. Remove any currenlty installed versions of PurpleAirDataLogger
+3. Remove any currently installed versions of PurpleAirDataLogger
 
 ```bash
 python3 -m pip uninstall purpleair_data_logger


### PR DESCRIPTION
# Fix documentation typos and docstrings

## Summary

This PR fixes the documentation typo, grammar, capitalization, and docstring issues described in issue #384. It keeps the change focused to the README and Python docstring updates requested by the issue.

Fixes #384

## Changes

- Fixed typos and PurpleAir capitalization in the hardware variant sample README files and tests README.
- Clarified the SQLite capitalization in the SQLite logger table-creation docstring.
- Added missing return type documentation to the CSV file-opening docstring and PostgreSQL timestamp conversion docstring.

## Testing

- `sandbox-run "python3 -m pip install -r requirements.txt -r tests/requirements.txt && python3 -m unittest"` completed dependency installation, but reported `Ran 0 tests` / `NO TESTS RAN`.
- `sandbox-run "python3 -m pip install -r requirements.txt -r tests/requirements.txt && python3 -m unittest discover -s tests"` ran 14 discovered tests and failed with 13 pre-existing import/attribute errors around package exports such as `purpleair_data_logger.PurpleAirPrometheusDataLogger`; these failures are unrelated to this docs-only change.
- `sandbox-run "python3 -m pip install -r requirements.txt && python3 -m black --check purpleair_data_logger"` passed: 12 files would be left unchanged.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
